### PR TITLE
installer: don't 'direnv allow' implicitly with --skip-confirm

### DIFF
--- a/.github/actions/direnv/index.js
+++ b/.github/actions/direnv/index.js
@@ -3,6 +3,9 @@ const cp = require("child_process");
 
 async function run() {
     try {
+        // [tag:direnv-allow-ci] We always allow any directory; this helps us avoid
+        // cases where we want to make it 'easy' to run direnv on behalf of the user,
+        // like in the installer.
         cp.execSync('direnv allow', { encoding: "utf-8" });
         const envs = JSON.parse(cp.execSync('direnv export json', { encoding: "utf-8" }));
 

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -507,8 +507,11 @@ fn clone_src(args: &Args, scm: &Scm) -> Result<(), Report> {
         style(full_checkout_path.display()).bold()
     );
 
-    if args.skip_confirm
-        || Confirm::with_theme(&theme)
+    // NOTE: don't automatically allow the '.envrc' without confirmation, to be
+    // polite to the user; direnv can be dangerous, after all... and CI can handle
+    // this for us anyway. See [ref:direnv-allow-ci] for more details.
+    if !args.skip_confirm
+        && Confirm::with_theme(&theme)
             .with_prompt(format!(
                 r#"May I 'direnv allow' the .envrc file located in '{}'?"#,
                 style(full_checkout_path.display()).bold()


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/thoughtpolice/buck2-nix/pull/4).
* #5
* __->__ #4

installer: don't 'direnv allow' implicitly with --skip-confirm

