### PR TITLE
feat(direnv): start watchman service on dir entry

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -8,3 +8,6 @@ name=TARGETS
 
 [project]
 ignore=.git,.sl,.jj
+
+[buck2]
+file_watcher=watchman

--- a/.envrc
+++ b/.envrc
@@ -30,8 +30,8 @@ ERROR: Your user account must be part of the 'trusted-users' setting in your
 Nix configuration to use this project. Please add '$USER' to the
 'trusted-users' setting in either:
 
-  - your /etc/nixos/configuration.nix'
-  - your /etc/nix/nix.conf'
+  - your /etc/nixos/configuration.nix
+  - your /etc/nix/nix.conf
 
 EOF
   exit 1
@@ -55,6 +55,7 @@ fi
 
 # Enable the nix-community direnv integration
 if ! has nix_direnv_version || ! nix_direnv_version 2.2.0; then
+  # XXX FIXME (aseipp): just vendor this into the source tree?
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.0/direnvrc" "sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc="
 fi
 
@@ -66,3 +67,45 @@ nix_direnv_watch_file buck/nix/toolchains/default.nix
 
 # Enable the flake
 use flake ./buck/nix --accept-flake-config
+
+# [tag:auto-watchman] In order to help keep track of files more accurately, we
+# use Watchman, and we automatically start it if it's not already running, and
+# the user has allowed it. This is a bit of a hack, but it helps keep the shell
+# environment clean.
+if [ ! -f .use_watchman ]; then
+  # XXX FIXME (aseipp): prompt about this file to the user
+  echo "direnv: watchman: not enabling, because .use_watchman is missing"
+elif [ "$CI_RUNNING" = "true" ]; then
+  # XXX FIXME (aseipp): _should_ we enable watchman in CI?
+  echo "direnv: watchman: not enabling, because we're running in CI"
+elif [ "$(uname)" = "Darwin" ]; then
+  # XXX FIXME (aseipp): macOS support
+  echo "direnv: watchman: not enabling, because we're on macOS"
+else
+  # XXX FIXME (aseipp): shouldn't require systemd on Linux, but in practice
+  # systemd is the only option for multi-user Nix and the only thing supported by
+  # upstream, so it is what it is.
+  [ ! -d /run/systemd/system ] && \
+    echo "direnv: watchman: ERROR: cannot enable, because you aren't using systemd" && \
+    exit 1
+
+  export WATCHMAN_SOCK=$HOME/.watchman-socket
+  if ! systemctl --user is-active --quiet watchman; then
+    echo "direnv: watchman: no service active; starting a transient watchman.service user unit..."
+    systemd-run -q --user \
+      -u watchman.service \
+      --working-directory=$HOME \
+      -p StateDirectory=watchman \
+      -p StandardOutput=journal \
+      -p Restart=on-failure \
+      watchman --foreground \
+        -u "$WATCHMAN_SOCK" \
+        --logfile="$HOME/.config/watchman/log" \
+        --statefile="$HOME/.config/watchman/state" \
+        --pidfile="$HOME/.config/watchman/pid"
+
+    echo "direnv: watchman: ok, see 'systemctl --user status watchman.service' for details"
+  else
+    echo "direnv: watchman: service is already active, continuing..."
+  fi
+fi

--- a/.github/actions/direnv/index.js
+++ b/.github/actions/direnv/index.js
@@ -3,6 +3,11 @@ const cp = require("child_process");
 
 async function run() {
     try {
+        // export some variables to help direnv know it's in a CI environment,
+        // which may change some minor behavior.
+        core.exportVariable('CI_RUNNING', 'true');
+        core.exportVariable('CI_RUNNING_SYSTEM', 'github-actions');
+
         // [tag:direnv-allow-ci] We always allow any directory; this helps us avoid
         // cases where we want to make it 'easy' to run direnv on behalf of the user,
         // like in the installer.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.direnv
 
 **/node_modules
+
+.use_watchman

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,22 @@
+{
+    "enforce_root_files": true,
+    "root_files": [
+        ".watchmanconfig"
+    ],
+    "ignore_dirs": [
+        "buck-out",
+        "installer/target"
+    ],
+    "ignore_vcs": [
+        ".git",
+        ".sl",
+        ".jj",
+        ".hg"
+    ],
+    "illegal_fstypes": [
+        "nfs",
+        "cifs",
+        "smb"
+    ],
+    "illegal_fstypes_advice": "use a local directory"
+}


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/thoughtpolice/buck2-nix/pull/6).
* #7
* __->__ #6

feat(direnv): start watchman service on dir entry

Summary: With this, we start watchman on entry to the repository as a
transient, background systemd user service. We also set WATCHMAN_SOCK to the
file path of the socket it creates for any clients like buck to find it. At
this point, buck should be completely configured to talk with watchman directly
with no further intervention. You can see its status with:

    systemctl --user status watchman.service

The intent here is that watchman is better at keeping track of file changes
more efficiently, and will overall better integrate with systems like Sapling
and EdenFS in the long run. It also has a separate, more flexible file ignore
policy than Buck does by default; by default, unlike a VCS, buck tries to track
*all* files with very few exceptions and so ignores `.gitignore`; it often ends
up picking up spurious 'cargo build' artifacts during development as a result
e.g. when rust-analyzer creates target/ directories from vscode, `buck build`
and watchman will see these file changes when it shouldn't bother tracking
them. Not to mention all other kinds of build products.

By integrating buck with `watchman` and a proper `.watchmanconfig`, these files
can be and directories can be better ignored in the long run, though it does
result in a bit of repetition between this and .gitignore files, unfortunately.

Currently, there's no way to stop the service on direnv unload, not that we
would want to (it wouldn't be safe with multiple instances in a directory). So
it just lingers for as long as needed, for now, and can be deleted with:

    systemctl --user stop watchman.service

For now, this only kicks in if the user has touch'd the `.use_watchman` file in
the root of the repository.

Test Plan: `touch .use_watchman`, then `touch .envrc` to reset the environment,
and watch that the daemon is started by direnv. Do it again, and see it was not
started (because it exists.) Kill it, do it over again, and see it still works.
Finally, run many parallel `cargo build` actions while running `buck build ...`
over and over again to ensure it doesn't pick up cargo files anymore.

