### PR TITLE
fix(types): Use new buck2 types

### DIFF
--- a/buck/prelude/basics/alias.bzl
+++ b/buck/prelude/basics/alias.bzl
@@ -17,7 +17,7 @@ dependencies or outputs based on the platform.
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __alias_impl(ctx: "context") -> ["provider"]:
+def __alias_impl(ctx: AnalysisContext) -> list[Provider]:
     return ctx.attrs.actual.providers
 
 alias = rule(

--- a/buck/prelude/basics/download.bzl
+++ b/buck/prelude/basics/download.bzl
@@ -12,7 +12,7 @@
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def _download_tarball(ctx: "context") -> ["provider"]:
+def _download_tarball(ctx: AnalysisContext) -> list[Provider]:
     dl_script, _ = ctx.actions.write(
         "download_{}.sh".format(ctx.label.name),
         [
@@ -66,7 +66,7 @@ __tarball = rule(
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __file_impl(ctx: "context") -> ["provider"]:
+def __file_impl(ctx: AnalysisContext) -> list[Provider]:
     dl_script, _ = ctx.actions.write(
         "download_{}.sh".format(ctx.label.name),
         [

--- a/buck/prelude/basics/files.bzl
+++ b/buck/prelude/basics/files.bzl
@@ -16,7 +16,7 @@ ExportFileDescriptionMode = [ "reference", "copy" ]
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __filegroup_impl(ctx: "context") -> ["provider"]:
+def __filegroup_impl(ctx: AnalysisContext) -> list[Provider]:
     if type(ctx.attrs.srcs) == type({}):
         srcs = ctx.attrs.srcs
     else:
@@ -39,7 +39,7 @@ __filegroup = rule(
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __export_file_impl(ctx: "context") -> ["provider"]:
+def __export_file_impl(ctx: AnalysisContext) -> list[Provider]:
     copy = ctx.attrs.mode != "reference"
 
     if copy:

--- a/buck/prelude/basics/genrule.bzl
+++ b/buck/prelude/basics/genrule.bzl
@@ -12,7 +12,7 @@
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def _declare_output(ctx: "context", path: str.type) -> "artifact":
+def _declare_output(ctx: AnalysisContext, path: str) -> Artifact:
     if path == ".":
         return ctx.actions.declare_output("out", dir = True)
     elif path.endswith("/"):
@@ -20,7 +20,7 @@ def _declare_output(ctx: "context", path: str.type) -> "artifact":
     else:
         return ctx.actions.declare_output("out", path)
 
-def _project_output(out: "artifact", path: str.type) -> "artifact":
+def _project_output(out: Artifact, path: str) -> Artifact:
     if path == ".":
         return out
     elif path.endswith("/"):
@@ -28,9 +28,9 @@ def _project_output(out: "artifact", path: str.type) -> "artifact":
     else:
         return out.project(path, hide_prefix = True)
 
-## ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 
-def __genrule_impl(ctx: "context") -> ["provider"]:
+def __genrule_impl(ctx: AnalysisContext) -> list[Provider]:
     out_attr = ctx.attrs.out
     outs_attr = ctx.attrs.outs
 

--- a/buck/prelude/basics/paths.bzl
+++ b/buck/prelude/basics/paths.bzl
@@ -18,7 +18,7 @@ The corresponding unittest file is: fbcode/buck2/tests/targets/starlib/paths_tes
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def _basename(p: str.type) -> str.type:
+def _basename(p: str) -> str:
     """Returns the basename (i.e., the file portion) of a path.
 
     Note that if `p` ends with a slash, this function returns an empty string.
@@ -33,7 +33,7 @@ def _basename(p: str.type) -> str.type:
     """
     return p.rpartition("/")[-1]
 
-def _dirname(p: str.type) -> str.type:
+def _dirname(p: str) -> str:
     """Returns the dirname of a path.
 
     The dirname is the portion of `p` up to but not including the file portion
@@ -53,7 +53,7 @@ def _dirname(p: str.type) -> str.type:
         # os.path.dirname does.
         return prefix.rstrip("/")
 
-def _is_absolute(path: str.type) -> bool.type:
+def _is_absolute(path: str) -> bool:
     """Returns `True` if `path` is an absolute path.
 
     Args:
@@ -63,7 +63,7 @@ def _is_absolute(path: str.type) -> bool.type:
     """
     return path.startswith("/")
 
-def _join(path: str.type, *others) -> str.type:
+def _join(path: str, *others) -> str:
     """Joins one or more path components intelligently.
 
     This function mimics the behavior of Python's `os.path.join` function on POSIX
@@ -92,7 +92,7 @@ def _join(path: str.type, *others) -> str.type:
 
     return result
 
-def _normalize(path: str.type) -> str.type:
+def _normalize(path: str) -> str:
     """Normalizes a path, eliminating double slashes and other redundant segments.
 
     This function mimics the behavior of Python's `os.path.normpath` function on
@@ -147,7 +147,7 @@ def _normalize(path: str.type) -> str.type:
 
     return path or "."
 
-def _relativize(path: str.type, start: str.type) -> str.type:
+def _relativize(path: str, start: str) -> str:
     """Returns the portion of `path` that is relative to `start`.
 
     Because we do not have access to the underlying file system, this
@@ -184,7 +184,7 @@ def _relativize(path: str.type, start: str.type) -> str.type:
     result_segments = segments[-length:]
     return "/".join(result_segments)
 
-def _replace_extension(p: str.type, new_extension: str.type) -> str.type:
+def _replace_extension(p: str, new_extension: str) -> str:
     """Replaces the extension of the file at the end of a path.
 
     If the path has no extension, the new extension is added to it.
@@ -198,7 +198,7 @@ def _replace_extension(p: str.type, new_extension: str.type) -> str.type:
     """
     return _split_extension(p)[0] + new_extension
 
-def _split_extension(p: str.type) -> (str.type, str.type):
+def _split_extension(p: str) -> (str, str):
     """Splits the path `p` into a tuple containing the root and extension.
 
     Leading periods on the basename are ignored, so
@@ -223,7 +223,7 @@ def _split_extension(p: str.type) -> (str.type, str.type):
     dot_distance_from_end = len(b) - last_dot_in_basename
     return (p[:-dot_distance_from_end], p[-dot_distance_from_end:])
 
-def _strip_suffix(a: str.type, b: str.type) -> [str.type, None]:
+def _strip_suffix(a: str, b: str) -> [str, None]:
     """Strip suffix `b` from path `a`, returning the resulting path.
 
     Args:
@@ -256,7 +256,7 @@ def _strip_suffix(a: str.type, b: str.type) -> [str.type, None]:
     # Return the original path, minus the suffix.
     return "/".join(pa[:len(pa) - len(pb)])
 
-def _starts_with(a: str.type, b: str.type) -> bool.type:
+def _starts_with(a: str, b: str) -> bool:
     """Returns `True` if `b` is a prefix path of `b`.
 
     Args:

--- a/buck/prelude/basics/pkg.bzl
+++ b/buck/prelude/basics/pkg.bzl
@@ -25,7 +25,7 @@ __VALID_OWNERS = [
     "@aseipp"
 ]
 
-def owner(name: "string") -> "NoneType":
+def owner(name: str) -> None:
     """Set the owner of the current package."""
 
     if name not in __VALID_OWNERS:
@@ -38,15 +38,15 @@ def owner(name: "string") -> "NoneType":
 
     return write_package_value('meta.owner', name)
 
-def license(s: "string") -> "NoneType":
+def license(s: str) -> None:
     """Set the license of the current package."""
     return write_package_value('meta.license', s.strip())
 
-def description(s: "string") -> "NoneType":
+def description(s: str) -> None:
     """Set the description of the current package."""
     return write_package_value('meta.description', s.strip())
 
-def version(s: "string") -> "NoneType":
+def version(s: str) -> None:
     """Set the version of the current package."""
 
     # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string

--- a/buck/prelude/basics/types.bzl
+++ b/buck/prelude/basics/types.bzl
@@ -23,7 +23,7 @@ load("@prelude//toolchains/zip/main.bzl", "zipfile");
 attributes = { }
 
 # Global providers. Key->value pairs of provider names and their types.
-providers: {str.type: "provider"} = { }
+providers: dict[str, Provider] = { }
 
 ## ---------------------------------------------------------------------------------------------------------------------
 

--- a/buck/prelude/platform/defs.bzl
+++ b/buck/prelude/platform/defs.bzl
@@ -12,7 +12,7 @@
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def _execution_platform_impl(ctx: "context") -> ["provider"]:
+def _execution_platform_impl(ctx: AnalysisContext) -> list[Provider]:
     constraints = dict()
     constraints.update(ctx.attrs.cpu_configuration[ConfigurationInfo].constraints)
     constraints.update(ctx.attrs.os_configuration[ConfigurationInfo].constraints)
@@ -89,14 +89,14 @@ __execution_platform = rule(
     },
 )
 
-def _host_cpu_configuration() -> str.type:
+def _host_cpu_configuration() -> str:
     arch = host_info().arch
     if arch.is_aarch64:
         return "prelude//platform/cpu:aarch64"
     else:
         return "prelude//platform/cpu:x86_64"
 
-def _host_os_configuration() -> str.type:
+def _host_os_configuration() -> str:
     os = host_info().os
     if os.is_macos:
         return "prelude//platform/os:darwin"

--- a/buck/prelude/toolchains/bash/main.bzl
+++ b/buck/prelude/toolchains/bash/main.bzl
@@ -13,7 +13,7 @@ load("@prelude//basics/files.bzl", "files")
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __run_impl(ctx: "context") -> ["provider"]:
+def __run_impl(ctx: AnalysisContext) -> list[Provider]:
     cmd = [ cmd_args(ctx.attrs._sh[DefaultInfo].default_outputs[0], format="{}/bin/osh") ]
     cmd.append(ctx.attrs.args)
 

--- a/buck/prelude/toolchains/cxx/main.bzl
+++ b/buck/prelude/toolchains/cxx/main.bzl
@@ -23,7 +23,7 @@ __toolchain_attrs = {
 CxxToolchainInfo = provider(fields = __toolchain_attrs.keys())
 CxxPlatformInfo = provider(fields = [ "name" ])
 
-def ctx2toolchain(ctx: "context") -> "CxxToolchainInfo":
+def ctx2toolchain(ctx: AnalysisContext) -> CxxToolchainInfo:
     info = ctx.attrs.toolchain[CxxToolchainInfo]
     attrs = dict()
     for k, default in __toolchain_attrs.items():
@@ -31,7 +31,7 @@ def ctx2toolchain(ctx: "context") -> "CxxToolchainInfo":
         attrs[k] = default if v == None else v
     return CxxToolchainInfo(**attrs)
 
-def __clang_toolchain_impl(ctx: "context") -> ["provider"]:
+def __clang_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     name = ctx.label.name
     version = ctx.attrs.version
     pkg = ctx.attrs.pkg
@@ -60,7 +60,7 @@ __clang_toolchain = nix.macros.toolchain_rule(
     },
 )
 
-def __binary_impl(ctx: "context") -> ["provider"]:
+def __binary_impl(ctx: AnalysisContext) -> list[Provider]:
     toolchain = ctx2toolchain(ctx)
     name = ctx.attrs.out if ctx.attrs.out else ctx.label.name
     identifier = name

--- a/buck/prelude/toolchains/nixpkgs.bzl
+++ b/buck/prelude/toolchains/nixpkgs.bzl
@@ -12,7 +12,7 @@ load("@prelude//basics/files.bzl", "files")
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __nix_build(ctx: "context", build_name: str.type, expr, binary: [str.type, None] = None) -> ["provider"]:
+def __nix_build(ctx: AnalysisContext, build_name: str, expr, binary: str | None = None) -> list[Provider]:
     nixpkgs = ctx.attrs._nixpkgs[DefaultInfo].default_outputs[0]
 
     deps = [o[DefaultInfo].default_outputs[0] for o in ctx.attrs.deps]
@@ -112,8 +112,8 @@ __build = rule(
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __get_toolchain(key: str.type, name: str.type, ps: ["_a"]) -> "attribute":
-    name: str.type = "@prelude//toolchains/{}:{}".format(key, name)
+def __get_toolchain(key: str, name: str, ps: list[typing.Any]) -> Attr:
+    name: str = "@prelude//toolchains/{}:{}".format(key, name)
     return attrs.toolchain_dep(default = name, providers = ps)
 
 def __toolchain_rule(impl, attrs, **kwargs):

--- a/buck/prelude/toolchains/prolog/main.bzl
+++ b/buck/prelude/toolchains/prolog/main.bzl
@@ -11,7 +11,7 @@
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __scryer_program_impl(ctx: "context") -> ["provider"]:
+def __scryer_program_impl(ctx: AnalysisContext) -> list[Provider]:
     default_start_name = "{}.pro".format(ctx.label.name)
     entrypoint = ctx.attrs.start
     if entrypoint == None:

--- a/buck/prelude/toolchains/rust/main.bzl
+++ b/buck/prelude/toolchains/rust/main.bzl
@@ -24,7 +24,7 @@ __toolchain_attrs = {
 RustToolchainInfo = provider(fields = __toolchain_attrs.keys())
 RustPlatformInfo = provider(fields = [ "name" ])
 
-def ctx2toolchain(ctx: "context") -> "RustToolchainInfo":
+def ctx2toolchain(ctx: AnalysisContext) -> RustToolchainInfo:
     info = ctx.attrs._toolchain[RustToolchainInfo]
     attrs = dict()
     for k, default in __toolchain_attrs.items():
@@ -32,7 +32,7 @@ def ctx2toolchain(ctx: "context") -> "RustToolchainInfo":
         attrs[k] = default if v == None else v
     return RustToolchainInfo(**attrs)
 
-def __toolchain_impl(ctx: "context") -> ["provider"]:
+def __toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     name = ctx.label.name
     channel = ctx.attrs.channel
     version = ctx.attrs.version
@@ -72,7 +72,7 @@ __toolchain = nix.macros.toolchain_rule(
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __binary_impl(ctx: "context") -> ["provider"]:
+def __binary_impl(ctx: AnalysisContext) -> list[Provider]:
     toolchain = ctx2toolchain(ctx)
     name = ctx.attrs.out if ctx.attrs.out else ctx.label.name
     identifier = ctx.attrs.file.basename

--- a/buck/prelude/toolchains/zip/main.bzl
+++ b/buck/prelude/toolchains/zip/main.bzl
@@ -10,7 +10,7 @@
 
 ## ---------------------------------------------------------------------------------------------------------------------
 
-def __create_impl(ctx: "context") -> ["provider"]:
+def __create_impl(ctx: AnalysisContext) -> list[Provider]:
     out_name = ctx.attrs.out if ctx.attrs.out else "{}.zip".format(ctx.label.name)
     out = ctx.actions.declare_output(out_name)
 


### PR DESCRIPTION
Summary: 

###### Summary

Buck2 seems to have moved away from stringified types and now needs types as defined [here](https://github.com/facebook/buck2/blob/main/starlark-rust/docs/types.md).

###### Test Plan

`buck build ...` fails with type error on previous commits.  Succeeds on this commit.

<!-- Boilerplate:start -->

###### Things done

<!-- Please check any boxes that apply. -->

- [x] Compiled all jobs and tested with `nix flake check`
- [ ] Assured whether relevant documentation is up to date.
- [ ] Describes relevance to desired tickets.
- [ ] Fits **[CONTRIBUTING.md]**.

<!-- Only links/markdown follow from here -->

[SECURITY.md]:     https://github.com/thoughtpolice/bors-tests/blob/master/.github/SECURITY.md
[SUPPORT.md]:      https://github.com/thoughtpolice/bors-tests/blob/master/.github/SUPPORT.md
[CONTRIBUTING.md]: https://github.com/thoughtpolice/bors-tests/blob/master/.github/CONTRIBUTING.md
